### PR TITLE
Perl Image followups

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Build image
+name: Build images
 
 on:
   push:
@@ -13,12 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Build base perl image
+      - name: Build images
         run: |
           docker version
           [ -n $DEBIAN_PROXY ] && docker_build_opts="--build-arg=DEBIAN_PROXY=${DEBIAN_PROXY}"
           docker build "$docker_build_opts" -t deriv/perl .
+          cd dzil && docker build "$docker_build_opts" -t deriv/dzil .
       - name: Inspect image creation and tag time
         run: |
           docker image inspect --format \'{{.Created}}\' deriv/perl
           docker image inspect --format \'{{.Metadata.LastTagTime}}\' deriv/perl
+          docker image inspect --format \'{{.Created}}\' deriv/dzil
+          docker image inspect --format \'{{.Metadata.LastTagTime}}\' deriv/dzil

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,8 @@ ONBUILD RUN if [ -r /app/aptfile ]; then \
 
 ONBUILD ADD . /app/
 
+ONBUILD RUN rm -f /etc/apt/apt.conf.d/30proxy
+
 ENTRYPOINT [ "/usr/bin/dumb-init", "--" ]
 
 CMD [ "perl", "app.pl" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,13 +56,12 @@ ONBUILD ADD cpanfile aptfile /app/
 # go through the CPAN deps. Once those are all done, remove anything
 # that we would have pulled in as a build dep (compilers, for example)
 # unless they happened to be in the aptfile.
-ONBUILD RUN if [ -s /app/aptfile ]; then \
+ONBUILD RUN if [ -r /app/aptfile ]; then \
     apt-get -y -q update \
     && apt-get -y -q --no-install-recommends install $(cat /app/aptfile); \
   fi \
   && cpanm --notest --quiet --installdeps --with-recommends . \
   && apt-get purge -y -q $(perl -le'@seen{split " ", "" . do { local ($/, @ARGV) = (undef, "/app/aptfile"); <> }} = () if -r "aptfile"; print for grep { !exists $seen{$_} } qw(make gcc git openssh-client libc6-dev libssl-dev zlib1g-dev)') \
-  && apt-get -y --purge autoremove \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /root/.cpanm /tmp/*
 
 ONBUILD ADD . /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ ONBUILD RUN if [ -r /app/aptfile ]; then \
     apt-get -y -q update \
     && apt-get -y -q --no-install-recommends install $(cat /app/aptfile); \
   fi \
-  && cpanm --notest --quiet --installdeps --with-recommends . \
+  && /usr/bin/dumb-init -- cpanm --notest --quiet --installdeps --with-recommends . \
   && apt-get purge -y -q $(perl -le'@seen{split " ", "" . do { local ($/, @ARGV) = (undef, "/app/aptfile"); <> }} = () if -r "aptfile"; print for grep { !exists $seen{$_} } qw(make gcc git openssh-client libc6-dev libssl-dev zlib1g-dev)') \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* /root/.cpanm /tmp/*
 

--- a/dzil/Dockerfile
+++ b/dzil/Dockerfile
@@ -1,0 +1,1 @@
+FROM deriv/perl

--- a/dzil/aptfile
+++ b/dzil/aptfile
@@ -1,2 +1,9 @@
+gcc
+git
+make
+openssh-client
+libc6-dev
+libssl-dev
+zlib1g-dev
 libncurses-dev
 libreadline-dev

--- a/dzil/aptfile
+++ b/dzil/aptfile
@@ -1,0 +1,2 @@
+libncurses-dev
+libreadline-dev

--- a/dzil/cpanfile
+++ b/dzil/cpanfile
@@ -1,0 +1,1 @@
+requires 'Dist::Zilla::PluginBundle::Author::DERIV';


### PR DESCRIPTION
- Add dzil image recipe (both as new base for the existing https://hub.docker.com/r/deriv/dzil image and as an example of how to use `deriv/perl`)
- Don't be too eager to purge auto-removable packages lest CPAN dependencies break, and make aptfile skippable if not present