### PR TITLE
Build without taint support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN [ -n "$DEBIAN_PROXY" ] \
  && echo "${PERL_SHA256} *perl-${PERL_VERSION}.tar.xz" | sha256sum -c - \
  && tar --strip-components=1 -xaf "perl-${PERL_VERSION}".tar.xz -C /usr/src/perl \
  && rm "perl-${PERL_VERSION}".tar.xz \
- && ./Configure -Duse64bitall -Duseshrplib -Dprefix=/opt/"perl-${PERL_VERSION}" -Dman1dir=none -Dman3dir=none -des \
+ && ./Configure -Duse64bitall -Duseshrplib -Dprefix=/opt/"perl-${PERL_VERSION}" -Dman1dir=none -Dman3dir=none -DSILENT_NO_TAINT_SUPPORT -des \
  && make -j$(nproc) \
  && make install \
  && cd /usr/src \


### PR DESCRIPTION
There's an overall performance hit when this is enabled, and core perl
is making it easier (and more common) to disable taint in newer builds,
so we might as well apply this. Actual performance difference varies but
in our tests have seen about 8-10%, other reports are as high as 15%.

(thanks to demerphq for the suggestion!)