### PR TITLE
feature/support_arm32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN [ -n "$http_proxy" ] \
  && echo "${PERL_SHA256} *perl-${PERL_VERSION}.tar.xz" | sha256sum -c - \
  && tar --strip-components=1 -xaf "perl-${PERL_VERSION}".tar.xz -C /usr/src/perl \
  && rm "perl-${PERL_VERSION}".tar.xz \
- && ./Configure -Duse64bitall -Duseshrplib -Dprefix=/opt/"perl-${PERL_VERSION}" -Dman1dir=none -Dman3dir=none -DSILENT_NO_TAINT_SUPPORT -des \
+ && ./Configure -D$(if [ `echo x64` == "armhf" ]; then echo "64bitint"; else echo "64bitall"; fi) -Duseshrplib -Dprefix=/opt/"perl-${PERL_VERSION}" -Dman1dir=none -Dman3dir=none -DSILENT_NO_TAINT_SUPPORT -des \
  && make -j$(nproc) \
  && make install \
  && cd /usr/src \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN [ -n "$http_proxy" ] \
  && echo "${PERL_SHA256} *perl-${PERL_VERSION}.tar.xz" | sha256sum -c - \
  && tar --strip-components=1 -xaf "perl-${PERL_VERSION}".tar.xz -C /usr/src/perl \
  && rm "perl-${PERL_VERSION}".tar.xz \
- && ./Configure -D$(if [ `echo x64` == "armhf" ]; then echo "64bitint"; else echo "64bitall"; fi) -Duseshrplib -Dprefix=/opt/"perl-${PERL_VERSION}" -Dman1dir=none -Dman3dir=none -DSILENT_NO_TAINT_SUPPORT -des \
+ && ./Configure -D`if [ \`arch | cut -b1-4 \` = "armv" ]; then echo "64bitint"; else echo "64bitall"; fi` -Duseshrplib -Dprefix=/opt/"perl-${PERL_VERSION}" -Dman1dir=none -Dman3dir=none -DSILENT_NO_TAINT_SUPPORT -des \
  && make -j$(nproc) \
  && make install \
  && cd /usr/src \

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # docker-perl
+
 Up-to-date Perl image with support for cpanfile and Debian dependencies
+
+For a cross-platform build, supporting arm+x64 architectures, we recommend using buildx:
+
+```
+docker buildx build --build-arg http_proxy="$http_proxy" --pull --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --tag deriv/perl:latest .
+```


### PR DESCRIPTION
Allow 64-bit integer, rather than requiring full 64-bit support, mostly for `armhf`/`armv7` platforms.