### PR TITLE
Require recent version of the DERIV plugin bundle

### DIFF
--- a/dzil/cpanfile
+++ b/dzil/cpanfile
@@ -1,1 +1,1 @@
-requires 'Dist::Zilla::PluginBundle::Author::DERIV';
+requires 'Dist::Zilla::PluginBundle::Author::DERIV', '>= 0.004';


### PR DESCRIPTION
Dependencies tend to change between versions, so make sure we have an explicit version definition here.