### PR TITLE
Ensure toolchain is available when installing `dzil authordeps`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,8 @@ ENV PATH="/opt/perl-${PERL_VERSION}/bin:/sbin:/bin:/usr/sbin:/usr/bin:/usr/local
 
 ONBUILD ARG HTTP_PROXY
 ONBUILD WORKDIR /app/
-ONBUILD COPY cpanfile aptfile /app/
+# Conditional copy - we want whichever files exist, and we'd typically expect to see at least one
+ONBUILD COPY aptfil[e] cpanfil[e] /app/
 
 # Install everything in the aptfile first, as system deps, then
 # go through the CPAN deps. Once those are all done, remove anything

--- a/dzil/Dockerfile
+++ b/dzil/Dockerfile
@@ -6,8 +6,7 @@ WORKDIR /app/
 COPY pod-inherit.patch .
 RUN patch -p0 $(perldoc -lm Pod::Inherit) < pod-inherit.patch
 
-ONBUILD RUN prepare-apt-cpan.sh \
- && dzil authordeps | cpanm -n
 # Conditional copy - we want whichever files exist, and we'd typically expect to see at least one
 ONBUILD COPY aptfil[e] cpanfil[e] dist.in[i] /app/
+ONBUILD RUN prepare-apt-cpan.sh
 ONBUILD COPY . /app/

--- a/dzil/Dockerfile
+++ b/dzil/Dockerfile
@@ -2,10 +2,12 @@ FROM deriv/perl
 ARG http_proxy
 
 WORKDIR /app/
+# Note that this happens after the `cpanfile` installation step due to ONBUILD in deriv/perl
 COPY pod-inherit.patch .
 RUN patch -p0 $(perldoc -lm Pod::Inherit) < pod-inherit.patch
 
-ONBUILD COPY cpanfile aptfile dist.ini /app/
 ONBUILD RUN prepare-apt-cpan.sh \
  && dzil authordeps | cpanm -n
+# Conditional copy - we want whichever files exist, and we'd typically expect to see at least one
+ONBUILD COPY aptfil[e] cpanfil[e] dist.in[i] /app/
 ONBUILD COPY . /app/

--- a/prepare-apt-cpan.sh
+++ b/prepare-apt-cpan.sh
@@ -37,6 +37,9 @@ if [ -d /app/vendors ]; then
         if [ -e cpanfile ]; then
             cpanm --notest --installdeps --with-recommends .
         fi
+        if [ -e dist.ini ]; then
+            dzil authordeps | cpanm -n
+        fi
     done
 
     echo "export PERL5LIB=$PERL5LIB" >> ~/.bashrc


### PR DESCRIPTION
The `deriv/dzil` image tries to install any missing `dzil authordeps` modules, but since this runs after the `aptfile` cleanup we may not have the compiler or other toolchain requirements in place.

This now moves to the `prepare-apt-cpan.sh` script, so that we run the `dzil` steps immediately after the general `cpanm` installation.