### PR TITLE
Use buildx to create multi-platform Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,7 @@ jobs:
           name: 'Docker build'
           command: |
             docker build -t ${DOCKER_REGISTRY}/${DOCKER_REPO}:arm64-${CIRCLE_SHA1} .
+            docker push ${DOCKER_REGISTRY}/${DOCKER_REPO}:arm64-${CIRCLE_SHA1}
 
   create_amd64_image:
     machine:
@@ -99,6 +100,7 @@ jobs:
           name: 'Docker build'
           command: |
             docker build -t ${DOCKER_REGISTRY}/${DOCKER_REPO}:amd64-${CIRCLE_SHA1} .
+            docker push ${DOCKER_REGISTRY}/${DOCKER_REPO}:amd64-${CIRCLE_SHA1}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,16 @@
 version: 2.1
 orbs:
-  docker: circleci/docker@2.1.1
+  docker: circleci/docker@2.1.3
+parameters:
+  tag:
+    type: string
+    default: 'latest'
+  registry:
+    type: string
+    default: 'docker.io'
+  repo:
+    type: string
+    default: 'deriv/perl'
 aliases:
   - &filter_only_master
       branches:
@@ -63,10 +73,39 @@ jobs:
             - docker/push:
                 image: <<parameters.image>>
                 tag: 'latest'
+  create_arm64_image:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    resource_class: arm.medium
+    environment:
+      - DOCKER_REGISTRY: <<pipeline.parameters.registry>>
+      - DOCKER_REPO: <<pipeline.parameters.repo>>
+    steps:
+      - checkout
+      - run:
+          name: 'Docker build'
+          command: |
+            docker build -t ${DOCKER_REGISTRY}/${DOCKER_REPO}:arm64-${CIRCLE_SHA1} .
+
+  create_amd64_image:
+    machine:
+      image: ubuntu-2204:2022.07.1
+    environment:
+      - DOCKER_REGISTRY: <<pipeline.parameters.registry>>
+      - DOCKER_REPO: <<pipeline.parameters.repo>>
+    steps:
+      - checkout
+      - run:
+          name: 'Docker build'
+          command: |
+            docker build -t ${DOCKER_REGISTRY}/${DOCKER_REPO}:amd64-${CIRCLE_SHA1} .
+
 workflows:
   version: 2
   build-workflow:
     jobs:
+      - create_arm64_image
+      - create_amd64_image
       - build_and_publish: *options_workflow_perl
       - build_and_publish: *options_workflow_dzil
       - docker/hadolint: *options_hadolint


### PR DESCRIPTION
Initial target is amd64/arm64 for Raspberry Pi/Graviton support.

See also https://github.com/binary-com/perl-Myriad/pull/257 which will depend on having proper upstream images.